### PR TITLE
CA-8 (config): Add GitHub Actions workflow to run unit tests

### DIFF
--- a/src/main/resources/.github/workflows/test.yml
+++ b/src/main/resources/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run Unit Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 26
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '26'
+          cache: maven
+
+      - name: Run tests
+        run: ./mvnw test


### PR DESCRIPTION
Created a workflow for GitHub Actions to automate running unit tests  on `push` and `pull_request` events for the `main` and `master` branches.

Configured the workflow to run on `ubuntu-latest`, set up JDK 26 with Maven caching, and execute the test suite using the `./mvn test` command.