### PR TITLE
CA-1 (feat): Implement data models and repositories for assets

### DIFF
--- a/src/main/java/com/yahoo_fin/scrapper/asset/crypto/Crypto.java
+++ b/src/main/java/com/yahoo_fin/scrapper/asset/crypto/Crypto.java
@@ -6,6 +6,8 @@ import lombok.Setter;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -27,6 +29,9 @@ public class Crypto {
     @Enumerated(EnumType.STRING)
     private Currency currency;
     private LocalDateTime last_updated;
+
+    @OneToMany(mappedBy = "crypto")
+    private List<CryptoPrice> cryptoPrices = new ArrayList<>();
 
     public enum Currency {
         USD,

--- a/src/main/java/com/yahoo_fin/scrapper/asset/crypto/CryptoPrice.java
+++ b/src/main/java/com/yahoo_fin/scrapper/asset/crypto/CryptoPrice.java
@@ -1,4 +1,4 @@
-package com.yahoo_fin.scrapper.asset.stock;
+package com.yahoo_fin.scrapper.asset.crypto;
 
 
 import jakarta.persistence.*;
@@ -10,16 +10,16 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Entity
-@Table(name = "stock_price")
-public class StockPrice {
-
+@Table(name = "crypto_price")
+public class CryptoPrice {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private double priceUSD;
     private LocalDateTime timestamp;
 
     @ManyToOne
-    @JoinColumn(name = "stock_id")
-    private Stock stock;
+    @JoinColumn(name = "crypto_id")
+    private Crypto crypto;
 }

--- a/src/main/java/com/yahoo_fin/scrapper/asset/crypto/CryptoPriceRepository.java
+++ b/src/main/java/com/yahoo_fin/scrapper/asset/crypto/CryptoPriceRepository.java
@@ -1,0 +1,9 @@
+package com.yahoo_fin.scrapper.asset.crypto;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CryptoPriceRepository  extends JpaRepository<CryptoPrice, Long> {
+    CryptoPrice findByCryptoAndTimestamp(Crypto crypto, java.time.LocalDateTime timestamp);
+    CryptoPrice findByCrypto(Crypto crypto);
+    CryptoPrice findByCryptoAndTimestampLessThanEqualOrderByTimestampDesc(Crypto crypto, java.time.LocalDateTime timestamp);
+}

--- a/src/main/java/com/yahoo_fin/scrapper/asset/stock/Stock.java
+++ b/src/main/java/com/yahoo_fin/scrapper/asset/stock/Stock.java
@@ -1,4 +1,37 @@
 package com.yahoo_fin.scrapper.asset.stock;
 
+
+import com.yahoo_fin.scrapper.market.Market;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@Setter
+@Entity
+@Table(name = "stock")
 public class Stock {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String companyName;
+    private String code;
+
+    @OneToOne(mappedBy = "stock", cascade = CascadeType.ALL)
+    private Market market;
+
+    @OneToMany(mappedBy = "stock")
+    private List<StockPrice> stockPrices = new ArrayList<>();
+
+    public Stock() {}
+    public Stock(String companyName, String code, Market market) {
+        this.companyName = companyName;
+        this.code = code;
+        this.market = market;
+    }
+
 }

--- a/src/main/java/com/yahoo_fin/scrapper/asset/stock/StockPriceRepository.java
+++ b/src/main/java/com/yahoo_fin/scrapper/asset/stock/StockPriceRepository.java
@@ -1,0 +1,10 @@
+package com.yahoo_fin.scrapper.asset.stock;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockPriceRepository extends JpaRepository<StockPrice, Long> {
+    StockPrice findByStockAndTimestamp(Stock stock, java.time.LocalDateTime timestamp);
+    StockPrice findByStock(Stock stock);
+    StockPrice findByStockAndTimestampLessThanEqualOrderByTimestampDesc(Stock stock, java.time.LocalDateTime timestamp);
+}

--- a/src/main/java/com/yahoo_fin/scrapper/asset/stock/StockRepository.java
+++ b/src/main/java/com/yahoo_fin/scrapper/asset/stock/StockRepository.java
@@ -1,0 +1,10 @@
+package com.yahoo_fin.scrapper.asset.stock;
+
+import com.yahoo_fin.scrapper.market.Market;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository  extends JpaRepository<Stock, Long> {
+    Stock findByCompanyNameEqualsIgnoreCase(String name);
+    Stock findByCodeEqualsIgnoreCase(String symbol);
+    Stock findByMarket(Market market);
+}

--- a/src/main/java/com/yahoo_fin/scrapper/market/Country.java
+++ b/src/main/java/com/yahoo_fin/scrapper/market/Country.java
@@ -12,8 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @Entity
-@Table(
-        name = "country")
+@Table(name = "country")
 public class Country {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/yahoo_fin/scrapper/market/Market.java
+++ b/src/main/java/com/yahoo_fin/scrapper/market/Market.java
@@ -1,6 +1,7 @@
 package com.yahoo_fin.scrapper.market;
 
 
+import com.yahoo_fin.scrapper.asset.stock.Stock;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,4 +26,8 @@ public class Market {
     @ManyToOne
     @JoinColumn(name = "country_id")
     private Country country;
+
+    @OneToOne
+    @JoinColumn(name = "stock_id")
+    private Stock stock;
 }

--- a/src/main/java/com/yahoo_fin/scrapper/market/MarketRepository.java
+++ b/src/main/java/com/yahoo_fin/scrapper/market/MarketRepository.java
@@ -1,0 +1,9 @@
+package com.yahoo_fin.scrapper.market;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketRepository extends JpaRepository<Market, Long> {
+    Market findByNameEqualsIgnoreCase(String name);
+    Market findByCodeEqualsIgnoreCase(String code);
+    Market findByCountry(Country country);
+}


### PR DESCRIPTION
Added persistence models and repositories for `CryptoPrice`, `StockPrice`, and `Market` with appropriate JPA relations like `OneToMany`, `ManyToOne`, and `OneToOne`.

- Implemented `CryptoPriceRepository`, `StockPriceRepository`, `MarketRepository`, and `StockRepository` for data access operations.
- Enhanced `Crypto` and `Stock` entities with relations to their respective price entities.
- Updated `Market` to reflect its association with `Stock`.

These changes set the foundation for managing asset pricing and their relations in the scrapping module.