### PR TITLE
CA-22 (config): Use environment variables for config values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
-name: Run Unit Tests
+name: Unit Tests
 
 on:
-  push:
-    branches: [ main, master ]
   pull_request:
+    branches: [ main, master ]
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ buildNumber.properties
 .classpath
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,java,intellij+all,database,macos
+/.env

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,12 +1,14 @@
 spring.application.name=scrapper
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/scrapper_db
-spring.datasource.username=postgres
-spring.datasource.password=postgres
-spring.datasource.driver-class-name=org.postgresql.Driver
+spring.config.import=optional:file:.env[.properties]
+
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
-spring.jackson.time-zone=UTC
+spring.jackson.time-zone=${DEFAULT_TIMEZONE}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=scrapper
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/scrapper_db
-spring.datasource.username=postgres
-spring.datasource.password=postgres
-spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
-spring.jackson.time-zone=UTC
+spring.jackson.time-zone=${DEFAULT_TIMEZONE}


### PR DESCRIPTION
Replaced hardcoded database and timezone configurations in `application.properties` and `application-local.properties` with environment variables. Introduced `.env` support for managing these variables locally by adding `spring.config.import=optional:file:.env`.

Updated `.gitignore` to exclude `.env` from version control, ensuring environment-specific values are not included in the repository.

These changes improve security and flexibility in managing sensitive configuration.

close #22 