### PR TITLE
feat(api): add models and configuration for external API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ buildNumber.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,java,intellij+all,database,macos
 /.env
+/.junie/*

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/src/main/java/com/yahoo_fin/scrapper/config/ExternalAPIProps.java
+++ b/src/main/java/com/yahoo_fin/scrapper/config/ExternalAPIProps.java
@@ -1,0 +1,29 @@
+package com.yahoo_fin.scrapper.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix="external.api")
+public class ExternalAPIProps {
+    private String baseUrl;
+    private String key;
+    private int timeoutSec = 10;
+    private int retryCount = 3;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public int getTimeoutSec() {
+        return timeoutSec;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+}

--- a/src/main/java/com/yahoo_fin/scrapper/config/WebClientConfig.java
+++ b/src/main/java/com/yahoo_fin/scrapper/config/WebClientConfig.java
@@ -1,0 +1,34 @@
+package com.yahoo_fin.scrapper.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(ExternalAPIProps props) {
+        HttpClient httpClient = HttpClient.create()
+                .responseTimeout(Duration.ofSeconds(props.getTimeoutSec()));
+
+        WebClient.Builder builder = WebClient.builder()
+                .baseUrl(props.getBaseUrl())
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient));
+
+        if (props.getRetryCount() > 0) {
+            builder.filter((request, next) -> next.exchange(request)
+                    .retryWhen(Retry.fixedDelay(props.getRetryCount(), Duration.ofSeconds(1))));
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/com/yahoo_fin/scrapper/types/CryptoDailyResponse.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/CryptoDailyResponse.java
@@ -1,0 +1,29 @@
+package com.yahoo_fin.scrapper.types;
+
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Setter
+@Getter
+public class CryptoDailyResponse {
+
+    private String code;
+    private String name;
+    private MonetaryValue price;
+    private boolean is_close;
+
+    public CryptoDailyResponse(String code, String name, MonetaryValue price, boolean is_close) {
+        this.code = code;
+        this.name = name;
+        this.price = price;
+        this.is_close = is_close;
+    }
+
+    public CryptoDailyResponse(String code, String name, MonetaryValue price) {
+        this.code = code;
+        this.name = name;
+        this.price = price;
+        this.is_close = false;
+    }
+}

--- a/src/main/java/com/yahoo_fin/scrapper/types/StockDailyResponse.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/StockDailyResponse.java
@@ -1,0 +1,32 @@
+package com.yahoo_fin.scrapper.types;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class StockDailyResponse {
+    private String code;
+    private String companyName;
+    private LocalDateTime timestamp;
+    private MonetaryValue price;
+    private boolean is_close;
+
+    public StockDailyResponse(String code, String companyName, LocalDateTime timestamp, MonetaryValue price, boolean is_close) {
+        this.code = code;
+        this.companyName = companyName;
+        this.timestamp = timestamp;
+        this.price = price;
+        this.is_close = is_close;
+    }
+
+    public StockDailyResponse(String code, String companyName, LocalDateTime timestamp, MonetaryValue price) {
+        this.code = code;
+        this.companyName = companyName;
+        this.timestamp = timestamp;
+        this.price = price;
+        this.is_close = false;
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -12,3 +12,8 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 spring.jackson.time-zone=${DEFAULT_TIMEZONE}
+
+external.api.base-url=${WEB_CLIENT_BASE_URL}
+external.api.key=${WEB_CLIENT_API_KEY}
+external.api.timeout-sec=300
+external.api.retry-count=3


### PR DESCRIPTION
- Introduced `CryptoDailyResponse` and `StockDailyResponse` data models to handle crypto and stock responses.
- Added `ExternalAPIProps` configuration for managing external API properties.
- Created `WebClientConfig` for external API interaction with customizable timeout and retry mechanisms.
- Included `spring-boot-starter-webflux` dependency to support reactive WebClient.
- Updated application properties to include external API configurations.
- Adjusted `.gitignore` to exclude `.junie` directory.