### PR TITLE
fix(workflow): randomize test execution order in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
           cache: maven
 
       - name: Run tests
-        run: ./mvnw test
+        run: ./mvnw test -Dsurefire.runOrder=random


### PR DESCRIPTION
- Updated `test.yml` to include `-Dsurefire.runOrder=random` for Maven test execution.
- Ensures tests are run in a non-deterministic order to identify potential interdependencies.

Closes #32 