### PR TITLE
feat(mapper): add YahooMapper for parsing ChartResponse and mapping t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>26</java.version>
+		<java.version>25</java.version>
 		<spring-cloud-azure.version>7.1.0</spring-cloud-azure.version>
 		<spring-cloud.version>2025.1.1</spring-cloud.version>
 	</properties>
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+			<version>1.18.42</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -151,6 +152,20 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.1</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.42</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/yahoo_fin/scrapper/types/yahoo/ChartResponse.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/yahoo/ChartResponse.java
@@ -1,0 +1,40 @@
+package com.yahoo_fin.scrapper.types.yahoo;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChartResponse {
+    private Chart chart;
+
+    @Data
+    public static class Chart {
+        private List<Result> result;
+    }
+
+    @Data
+    public static class Meta {
+        private String longName;
+        private String shortName;
+        private String instrumentType;
+    }
+
+    @Data
+    public static class Result {
+        private Meta meta;
+        private List<Long> timestamp;
+        private Indicators indicators;
+    }
+
+    @Data
+    public static class Indicators {
+        private List<Quote> quote;
+    }
+
+    @Data
+    public static class Quote {
+        private List<Double> close;
+    }
+}
+

--- a/src/main/java/com/yahoo_fin/scrapper/utils/YahooDataFetcher.java
+++ b/src/main/java/com/yahoo_fin/scrapper/utils/YahooDataFetcher.java
@@ -1,6 +1,7 @@
 package com.yahoo_fin.scrapper.utils;
 
 import com.yahoo_fin.scrapper.types.PriceResponse;
+import com.yahoo_fin.scrapper.types.yahoo.ChartResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,8 +13,8 @@ import java.util.List;
         configuration = YahooFeignConfig.class)
 public interface YahooDataFetcher {
 
-    @GetMapping("/stock/" + "${app.rapid-api-version}" + "/get-chart?interval=60m&range=1d&includePrePost=false&useYfid=true&includeAdjustedClose=true")
-    PriceResponse getStockPriceCurrent(@RequestParam("symbol") String symbol);
+    @GetMapping("/stock/" + "${app.rapid-api-version}" + "/get-chart?interval=1d&range=1d&includePrePost=false&useYfid=true&includeAdjustedClose=true")
+    ChartResponse getStockPriceCurrent(@RequestParam("symbol") String symbol);
 
     @GetMapping("/stock/" + "${app.rapid-api-version}" + "/get-chart?interval=1d&range=6mo&includePrePost=false&useYfid=true&includeAdjustedClose=true")
     List<PriceResponse> getStockPricePreviousSixMonths(@RequestParam("symbol") String symbol);

--- a/src/main/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapper.java
+++ b/src/main/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapper.java
@@ -1,0 +1,69 @@
+package com.yahoo_fin.scrapper.utils.mappers;
+
+import com.yahoo_fin.scrapper.types.MonetaryValue;
+import com.yahoo_fin.scrapper.types.PriceResponse;
+import com.yahoo_fin.scrapper.types.yahoo.ChartResponse;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+public class YahooMapper {
+    public enum InstrumentType {
+        EQUITY("EQUITY"),
+        CURRENCY("CURRENCY"),
+        CRYPTOCURRENCY("CRYPTOCURRENCY");
+
+        private final String value;
+
+        InstrumentType(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public List<PriceResponse> toPriceResponse(ChartResponse chartResponse){
+        InstrumentType responseType = getInstrumentType(chartResponse.getChart().getResult().getFirst().getMeta().getInstrumentType());
+        String assetCode = chartResponse.getChart().getResult().getFirst().getMeta().getShortName();
+        List<PriceResponse> priceResponses = new ArrayList<>();
+
+        if (responseType == InstrumentType.CURRENCY) {
+            assetCode = getCurrencyCodeFromShortName(assetCode);
+        }
+
+        List<Long> timestamps = chartResponse.getChart().getResult().getFirst().getTimestamp();
+        List<Double> prices = chartResponse.getChart().getResult().getFirst().getIndicators().getQuote().getFirst().getClose();
+
+        int tsIndex = 0;
+        for (Long timestamp : timestamps) {
+            if (prices.get(tsIndex) == null) {
+                tsIndex++;
+                continue;
+            }
+            MonetaryValue price = new MonetaryValue(prices.get(tsIndex));
+            String dataSource = "YAHOO_FINANCE";
+            PriceResponse priceResponse = new PriceResponse(
+                    dataSource,
+                    price,
+                    assetCode,
+                    responseType.getValue(),
+                    LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), ZoneId.systemDefault()));
+            priceResponses.add(priceResponse);
+            tsIndex++;
+        }
+        return priceResponses;
+    }
+
+    private InstrumentType getInstrumentType(String instrumentType) {
+        return InstrumentType.valueOf(instrumentType);
+    }
+
+    private String getCurrencyCodeFromShortName(String shortName) {
+        return shortName.split("/")[0];
+    }
+}

--- a/src/test/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapperTest.java
+++ b/src/test/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapperTest.java
@@ -1,0 +1,151 @@
+package com.yahoo_fin.scrapper.utils.mappers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo_fin.scrapper.types.PriceResponse;
+import com.yahoo_fin.scrapper.types.yahoo.ChartResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class YahooMapperTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final YahooMapper yahooMapper = new YahooMapper();
+
+    @Test
+    void testJsonMapperSingleDayResponse() throws Exception {
+        String yahooResponse = """
+                            {
+                              "chart": {
+                                "result": [
+                                  {
+                                    "meta": {
+                                      "longName": "Apple Inc.",
+                                      "shortName": "AAPL",
+                                      "instrumentType": "EQUITY"
+                                    },
+                                    "timestamp": [1710000000],
+                                    "indicators": {
+                                      "quote": [
+                                        {
+                                          "close": [180.5]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                """;
+        ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
+        assertEquals("Apple Inc.", chartResponse.getChart().getResult().getFirst().getMeta().getLongName());
+        assertEquals("AAPL", chartResponse.getChart().getResult().getFirst().getMeta().getShortName());
+        assertEquals("EQUITY", chartResponse.getChart().getResult().getFirst().getMeta().getInstrumentType());
+
+        assertEquals(1, chartResponse.getChart().getResult().getFirst().getTimestamp().size());
+        assertEquals(180.5, chartResponse.getChart().getResult().getFirst().getIndicators().getQuote().getFirst().getClose().getFirst(), 0.001);
+    }
+
+    @Test
+    void testJsonMapperMultipleDayResponse() throws Exception {
+        String yahooResponse = """
+                                    {
+                              "chart": {
+                                "result": [
+                                  {
+                                    "meta": {
+                                      "longName": "BitCoin",
+                                      "shortName": "BTC-US",
+                                      "instrumentType": "CRYPTOCURRENCY"
+                                    },
+                                    "timestamp": [1761001200,1761087600,1761174000],
+                                    "indicators": {
+                                      "quote": [
+                                        {
+                                          "close": [180.5,181.10,181.20]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+       """;
+        ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
+        assertEquals("BitCoin", chartResponse.getChart().getResult().getFirst().getMeta().getLongName());
+        assertEquals(3, chartResponse.getChart().getResult().getFirst().getTimestamp().size());
+        assertEquals(181.20, chartResponse.getChart().getResult().getFirst().getIndicators().getQuote().getFirst().getClose().get(2));
+    }
+
+    @Test
+    void testMapperWithSingleDayResponse() throws JsonProcessingException {
+        String yahooResponse = """
+                            {
+                              "chart": {
+                                "result": [
+                                  {
+                                    "meta": {
+                                      "longName": "Apple Inc.",
+                                      "shortName": "AAPL",
+                                      "instrumentType": "EQUITY"
+                                    },
+                                    "timestamp": [1710000000],
+                                    "indicators": {
+                                      "quote": [
+                                        {
+                                          "close": [180.5]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                """;
+        ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
+        List<PriceResponse> priceResponse = yahooMapper.toPriceResponse(chartResponse);
+
+        assertEquals(1, priceResponse.size());
+        assertEquals("AAPL", priceResponse.getFirst().getAssetCode());
+        assertEquals("EQUITY", priceResponse.getFirst().getAssetName());
+        assertEquals("2024-03-10T03:00", priceResponse.getFirst().getTimestamp().toString());
+        assertEquals(180.5, priceResponse.getFirst().getPrice().getRawValue());
+    }
+
+    @Test
+    void testMapperWithMultipleDayResponse() throws JsonProcessingException {
+        String yahooResponse = """
+                                    {
+                              "chart": {
+                                "result": [
+                                  {
+                                    "meta": {
+                                      "longName": "BitCoin",
+                                      "shortName": "BTC-US",
+                                      "instrumentType": "CRYPTOCURRENCY"
+                                    },
+                                    "timestamp": [1761001200,1761087600,1761174000],
+                                    "indicators": {
+                                      "quote": [
+                                        {
+                                          "close": [180.5,181.10,181.20]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                """;
+        ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
+        List<PriceResponse> priceResponse = yahooMapper.toPriceResponse(chartResponse);
+        assertEquals(3, priceResponse.size());
+        assertEquals("BTC-US", priceResponse.get(2).getAssetCode());
+        assertEquals("CRYPTOCURRENCY", priceResponse.get(2).getAssetName());
+        assertEquals("2025-10-23T10:00", priceResponse.get(2).getTimestamp().toString());
+        assertEquals(181.20, priceResponse.get(2).getPrice().getRawValue());
+    }
+
+}


### PR DESCRIPTION
…o PriceResponse

- Implemented `YahooMapper` to convert `ChartResponse` objects into `PriceResponse` for easier handling of financial data.
- Introduced nested data classes (`Chart`, `Meta`, `Result`, `Indicators`, `Quote`) in `ChartResponse` for representing API response structure.
- Added unit tests in `YahooMapperTest` to validate mapping logic for single and multi-day responses.
- Updated `YahooDataFetcher` to use `ChartResponse` instead of `PriceResponse` for API compatibility.
- Upgraded Lombok dependency in `pom.xml` and added Maven Compiler Plugin for annotation processing.
- Corrected Java version to align with project standards in `pom.xml`.

Refers to #39 