### PR TITLE
feat(mapper): add cryptocurrency symbol parsing to YahooMapper

### DIFF
--- a/src/main/java/com/yahoo_fin/scrapper/types/CurrencyResponse.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/CurrencyResponse.java
@@ -29,10 +29,6 @@ public class CurrencyResponse {
         this.timestamp = LocalDateTime.now();
     }
 
-    public static CurrencyResponse emptyCurrencyResponse() {
-        return new CurrencyResponse("", "", new MonetaryValue(0));
-    }
-
     public String getCurrencyName() {
         return currencyName;
     }

--- a/src/main/java/com/yahoo_fin/scrapper/types/MonetaryValue.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/MonetaryValue.java
@@ -1,10 +1,16 @@
 package com.yahoo_fin.scrapper.types;
 
+import lombok.Getter;
+
 import java.util.Locale;
 
 public class MonetaryValue {
+    @Getter
     private final int normalisedValue;
+
+    @Getter
     private final double rawValue;
+
     private final Locale currLocale = java.util.Locale.US;
     private final int powerOfTen = 2;
 
@@ -20,14 +26,6 @@ public class MonetaryValue {
             throw new IllegalArgumentException("Invalid monetary value format: " + sValue, e);
         }
         this.normalisedValue = (int) (this.rawValue * Math.pow(10, powerOfTen));
-    }
-
-    public double getRawValue() {
-        return rawValue;
-    }
-
-    public int getNormalisedValue() {
-        return normalisedValue;
     }
 
     public String toString() {

--- a/src/main/java/com/yahoo_fin/scrapper/types/yahoo/ChartResponse.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/yahoo/ChartResponse.java
@@ -18,6 +18,7 @@ public class ChartResponse {
         private String longName;
         private String shortName;
         private String instrumentType;
+        private String symbol;
     }
 
     @Data

--- a/src/main/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapper.java
+++ b/src/main/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapper.java
@@ -35,6 +35,10 @@ public class YahooMapper {
             assetCode = getCurrencyCodeFromShortName(assetCode);
         }
 
+        if (responseType == InstrumentType.CRYPTOCURRENCY) {
+            assetCode = getCryptoCodeFromSymbol(chartResponse.getChart().getResult().getFirst().getMeta().getSymbol());
+        }
+
         List<Long> timestamps = chartResponse.getChart().getResult().getFirst().getTimestamp();
         List<Double> prices = chartResponse.getChart().getResult().getFirst().getIndicators().getQuote().getFirst().getClose();
 
@@ -64,5 +68,9 @@ public class YahooMapper {
 
     private String getCurrencyCodeFromShortName(String shortName) {
         return shortName.split("/")[0];
+    }
+
+    private String getCryptoCodeFromSymbol(String symbol) {
+        return symbol.split("-")[0];
     }
 }

--- a/src/test/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapperTest.java
+++ b/src/test/java/com/yahoo_fin/scrapper/utils/mappers/YahooMapperTest.java
@@ -122,8 +122,9 @@ class YahooMapperTest {
                                 "result": [
                                   {
                                     "meta": {
-                                      "longName": "BitCoin",
-                                      "shortName": "BTC-US",
+                                      "longName": "Bitcoin USD",
+                                      "shortName": "Bitcoin USD",
+                                      "symbol": "BTC-US",
                                       "instrumentType": "CRYPTOCURRENCY"
                                     },
                                     "timestamp": [1761001200,1761087600,1761174000],
@@ -142,7 +143,7 @@ class YahooMapperTest {
         ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
         List<PriceResponse> priceResponse = yahooMapper.toPriceResponse(chartResponse);
         assertEquals(3, priceResponse.size());
-        assertEquals("BTC-US", priceResponse.get(2).getAssetCode());
+        assertEquals("BTC", priceResponse.get(2).getAssetCode());
         assertEquals("CRYPTOCURRENCY", priceResponse.get(2).getAssetName());
         assertEquals("2025-10-22T23:00", priceResponse.get(2).getTimestamp().toString());
         assertEquals(181.20, priceResponse.get(2).getPrice().getRawValue());


### PR DESCRIPTION
- Updated `YahooMapper` to extract cryptocurrency asset codes from `ChartResponse` symbols.
- Added support for new `symbol` field in `ChartResponse.Meta` for cryptocurrency handling.
- Introduced `getCryptoCodeFromSymbol` method for parsing cryptocurrency asset codes from `symbol` strings.
- Enhanced test coverage in `YahooMapperTest` to validate cryptocurrency-specific mappings.
- Refactored `MonetaryValue` by replacing manual getters with Lombok `@Getter` for cleaner code.
- Removed redundant `emptyCurrencyResponse()` method from `CurrencyResponse`.

Closes #45 