### PR TITLE
feat(currency): add `CurrencyController` and improve backfill & datab…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,5 +178,5 @@ buildNumber.properties
 .classpath
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,java,intellij+all,database,macos
-/.env
+/src/.env.properties
 /.junie/*

--- a/src/main/java/com/yahoo_fin/scrapper/currency/CurrencyRepository.java
+++ b/src/main/java/com/yahoo_fin/scrapper/currency/CurrencyRepository.java
@@ -3,9 +3,12 @@ package com.yahoo_fin.scrapper.currency;
 import com.yahoo_fin.scrapper.market.Country;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface CurrencyRepository extends JpaRepository<Currency, Long> {
     Currency findByNameEqualsIgnoreCase(String name);
     Currency findByCodeEqualsIgnoreCase(String code);
     Currency findByCountry(Country country);
+    List<Currency> findAllSortBy(String field);
 }

--- a/src/main/java/com/yahoo_fin/scrapper/currency/USDExchangeRateRepository.java
+++ b/src/main/java/com/yahoo_fin/scrapper/currency/USDExchangeRateRepository.java
@@ -13,4 +13,8 @@ public interface USDExchangeRateRepository extends JpaRepository<USDExchangeRate
     Optional<USDExchangeRate> findFirstByCurrencyOrderByTimestampDesc(Currency currency);
     Optional<USDExchangeRate> findFirstByCurrencyAndTimestamp(Currency currency, LocalDateTime timestamp);
     Optional<USDExchangeRate> findMaxByCurrency(Currency currency);
+    Integer countByCurrency(Currency currency);
+    Integer countByCurrencyAndTimestampLessThanEqual(Currency currency, LocalDateTime timestamp);
+    Integer countByCurrencyAndTimestamp(Currency currency, LocalDateTime timestamp);
+    Integer countByCurrencyAndTimestampGreaterThan(Currency currency, LocalDateTime timestamp);
 }

--- a/src/main/java/com/yahoo_fin/scrapper/currency/controller/CurrencyController.java
+++ b/src/main/java/com/yahoo_fin/scrapper/currency/controller/CurrencyController.java
@@ -1,0 +1,65 @@
+package com.yahoo_fin.scrapper.currency.controller;
+
+import com.yahoo_fin.scrapper.currency.Currency;
+import com.yahoo_fin.scrapper.currency.USDExchangeRate;
+import com.yahoo_fin.scrapper.currency.service.CurrencyListing;
+import com.yahoo_fin.scrapper.currency.service.YahooBackFiller;
+import com.yahoo_fin.scrapper.types.BackfillResponse;
+import com.yahoo_fin.scrapper.types.records.CurrencyRefill;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static java.time.ZoneOffset.UTC;
+
+@RestController
+public class CurrencyController {
+    private static final Logger logger = Logger.getLogger(CurrencyController.class.getName());
+
+    private final String currencyRootPath = "/currency";
+    private final YahooBackFiller yahooBackFiller;
+    private final CurrencyListing currencyListing;
+
+    public CurrencyController(YahooBackFiller yahooBackFiller, CurrencyListing currencyListing) {
+        this.yahooBackFiller = yahooBackFiller;
+        this.currencyListing = currencyListing;
+    }
+
+    @RequestMapping(value = currencyRootPath + "/back-fill",
+            method = RequestMethod.POST,
+            produces = "application/json")
+    public ResponseEntity<Object> backFill() {
+        BackfillResponse response = new BackfillResponse();
+        Map<String, BackfillResponse.CurrencyBackfillInfo> currencies = new HashMap<>();
+
+        LocalDateTime localDate = LocalDateTime.now(UTC);
+        response.setCurrentDatetime(localDate);
+        LocalDateTime cutDate = localDate.minusMonths(6);
+        List<Currency> currencyList = currencyListing.getCurrencyList();
+        logger.info("Starting backfill for \"" + currencyList.size() + "\" currencies");
+
+        for (Currency currency : currencyList) {
+            USDExchangeRate lastExchangeRecord = yahooBackFiller.getNewestRecord(currency);
+            logger.info("Fetching \"" + currency.getCode() + "\" exchange rate");
+            if (lastExchangeRecord.getCurrency() != null) {
+                cutDate = lastExchangeRecord.getTimestamp();
+            }
+            CurrencyRefill currencyRefill = yahooBackFiller.runBackfill(localDate, cutDate, currency);
+
+            BackfillResponse.CurrencyBackfillInfo info = new BackfillResponse.CurrencyBackfillInfo(
+                    lastExchangeRecord.getTimestamp(),
+                    currencyRefill.storedRecords());
+            currencies.put(currency.getCode(), info);
+        }
+        response.setCurrencies(currencies);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/yahoo_fin/scrapper/currency/service/CurrencyListing.java
+++ b/src/main/java/com/yahoo_fin/scrapper/currency/service/CurrencyListing.java
@@ -1,0 +1,22 @@
+package com.yahoo_fin.scrapper.currency.service;
+
+import com.yahoo_fin.scrapper.currency.Currency;
+import com.yahoo_fin.scrapper.currency.CurrencyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CurrencyListing {
+    private final CurrencyRepository currencyRepository;
+
+    public CurrencyListing(CurrencyRepository currencyRepository) {
+        this.currencyRepository = currencyRepository;
+    }
+
+    public List<Currency> getCurrencyList() {
+        return (currencyRepository.findAllSortBy("code"));
+    }
+
+}

--- a/src/main/java/com/yahoo_fin/scrapper/currency/service/YahooBackFiller.java
+++ b/src/main/java/com/yahoo_fin/scrapper/currency/service/YahooBackFiller.java
@@ -37,11 +37,9 @@ public class YahooBackFiller implements CurrencyBackfiller{
 
     @Override
     public CurrencyRefill runBackfill(LocalDateTime currentDateTime, LocalDateTime sinceDateTime, Currency currency) {
-        int cutOffMonths = 6;
-        LocalDateTime sinceDateTarget = sinceDateTime;
-        if (sinceDateTime.isBefore(currentDateTime.minusMonths(cutOffMonths))) {
-            sinceDateTarget = currentDateTime.minusMonths(cutOffMonths);
-        }
+        LocalDateTime maxAllowedBackFillDate = currentDateTime.minusMonths(6);
+        LocalDateTime cutDate = sinceDateTime.isBefore(maxAllowedBackFillDate) ? maxAllowedBackFillDate : sinceDateTime;
+
         String symbol = buildYahooSymbol(currency);
         ChartResponse chartResponse = yahooDataFetcher.getStockPricePreviousSixMonths(symbol);
         List<PriceResponse> exchangeRateResponsesToSave = yahooMapper.toPriceResponse(chartResponse);
@@ -49,7 +47,7 @@ public class YahooBackFiller implements CurrencyBackfiller{
 
         return new CurrencyRefill(
                 currency.getCode(),
-                saveExchangeRate(exchangeRateList, sinceDateTarget));
+                saveExchangeRate(exchangeRateList, cutDate));
     }
 
     private int saveExchangeRate(List<USDExchangeRate> exchangeRateToSave, LocalDateTime dateLimit) {

--- a/src/main/java/com/yahoo_fin/scrapper/market/controller/MarketController.java
+++ b/src/main/java/com/yahoo_fin/scrapper/market/controller/MarketController.java
@@ -1,0 +1,39 @@
+package com.yahoo_fin.scrapper.market.controller;
+
+import com.yahoo_fin.scrapper.market.service.DBPreFillerService;
+import lombok.Data;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+
+import java.util.logging.Logger;
+
+@RestController
+public class MarketController {
+
+    private static final Logger logger = Logger.getLogger(MarketController.class.getName());
+
+    private final String marketRootPath = "/market";
+    private final DBPreFillerService dbPreFillerService;
+
+    public MarketController(DBPreFillerService dbPreFillerService) {
+        this.dbPreFillerService = dbPreFillerService;
+    }
+
+    @RequestMapping(value = marketRootPath + "/prepare-db",
+            method = RequestMethod.POST,
+            produces = "application/json")
+    public ResponseEntity<Object> prepareDB() {
+        @Data
+        class prepareDBResponse {
+            String message;
+        }
+
+        logger.info("Preparing database");
+        dbPreFillerService.populateCountryAndMarketTables();
+        prepareDBResponse response = new prepareDBResponse();
+        response.message = "Database prepared";
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/yahoo_fin/scrapper/market/service/DBPreFillerService.java
+++ b/src/main/java/com/yahoo_fin/scrapper/market/service/DBPreFillerService.java
@@ -1,6 +1,8 @@
 package com.yahoo_fin.scrapper.market.service;
 
 import com.yahoo_fin.scrapper.AppProperties;
+import com.yahoo_fin.scrapper.currency.Currency;
+import com.yahoo_fin.scrapper.currency.CurrencyRepository;
 import com.yahoo_fin.scrapper.market.Country;
 import com.yahoo_fin.scrapper.market.CountryRepository;
 import com.yahoo_fin.scrapper.market.Market;
@@ -15,11 +17,13 @@ public class DBPreFillerService {
     private final CountryRepository countryRepository;
     private final MarketRepository marketRepository;
     private final AppProperties appProperties;
+    private final CurrencyRepository currencyRepository;
 
-    public DBPreFillerService(CountryRepository countryRepository, MarketRepository marketRepository, AppProperties appProperties) {
+    public DBPreFillerService(CountryRepository countryRepository, MarketRepository marketRepository, AppProperties appProperties, CurrencyRepository currencyRepository) {
         this.countryRepository = countryRepository;
         this.marketRepository = marketRepository;
         this.appProperties = appProperties;
+        this.currencyRepository = currencyRepository;
     }
 
     public void populateCountryAndMarketTables() {
@@ -30,11 +34,13 @@ public class DBPreFillerService {
             String countryName = market.getCountryName();
             String marketTicker = market.getMarketTicker();
             String marketName = market.getMarketName();
+            String currency = market.getCurrency();
 
             if (countryRepository.findByCodeEqualsIgnoreCase(countryCode).isEmpty()) {
                 Country country = new Country(countryName.toUpperCase(), countryCode.toUpperCase());
                 countryRepository.save(country);
                 addMarket(country, marketTicker, marketName);
+                addCurrency(country, countryName, currency);
             }
         }
     }
@@ -43,6 +49,14 @@ public class DBPreFillerService {
         if (marketRepository.findByCountry(country).isEmpty()) {
             Market market = new Market(marketName, marketTicker, country);
             marketRepository.save(market);
+        }
+    }
+
+    private void addCurrency(Country country, String currencyName, String currencyCode) {
+        Currency currencyByCountry = currencyRepository.findByCountry(country);
+        if (currencyByCountry == null) {
+            Currency currency = new Currency(currencyName, currencyCode, country);
+            currencyRepository.save(currency);
         }
     }
 }

--- a/src/main/java/com/yahoo_fin/scrapper/types/BackfillResponse.java
+++ b/src/main/java/com/yahoo_fin/scrapper/types/BackfillResponse.java
@@ -17,8 +17,13 @@ public class BackfillResponse {
     @Data
     public static class CurrencyBackfillInfo {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-
         private LocalDateTime mostRecentRecordTs;
+
         private int recordsToRefill;
+
+        public CurrencyBackfillInfo(LocalDateTime timestamp, Integer integer) {
+            this.mostRecentRecordTs = timestamp;
+            this.recordsToRefill = integer;
+        }
     }
 }

--- a/src/main/java/com/yahoo_fin/scrapper/utils/mappers/yahoo/YahooDataFetcher.java
+++ b/src/main/java/com/yahoo_fin/scrapper/utils/mappers/yahoo/YahooDataFetcher.java
@@ -6,16 +6,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name="yahoo-finance",
-        url = "${app.rapid-api-base-url}",
+        url = "https://yh-finance.p.rapidapi.com",
         configuration = YahooFeignConfig.class)
 public interface YahooDataFetcher {
 
-    @GetMapping("/stock/" + "${app.rapid-api-version}" + "/get-chart?interval=1d&range=1d&includePrePost=false&useYfid=true&includeAdjustedClose=true")
+    @GetMapping("/stock/" + "v3" + "/get-chart?interval=1d&range=1d&includePrePost=false&useYfid=true&includeAdjustedClose=true")
     ChartResponse getStockPriceCurrent(@RequestParam("symbol") String symbol);
 
-    @GetMapping("/stock/" + "${app.rapid-api-version}" + "/get-chart?interval=1d&range=6mo&includePrePost=false&useYfid=true&includeAdjustedClose=true")
+    @GetMapping("/stock/" + "v3" + "/get-chart?interval=1d&range=6mo&includePrePost=false&useYfid=true&includeAdjustedClose=true")
     ChartResponse getStockPricePreviousSixMonths(@RequestParam("symbol") String symbol);
 
-    @GetMapping ("/stock/" + "${app.rapid-api-version}" + "/get-chart?interval=1d&includePrePost=false&useYfid=true&includeAdjustedClose=true")
+    @GetMapping ("/stock/" + "v3" + "/get-chart?interval=1d&includePrePost=false&useYfid=true&includeAdjustedClose=true")
     ChartResponse getStockPriceFromToDate(@RequestParam("symbol") String symbol, @RequestParam("period1") String startDate, @RequestParam("period2") String endDate);
 }

--- a/src/main/java/com/yahoo_fin/scrapper/utils/mappers/yahoo/YahooFeignConfig.java
+++ b/src/main/java/com/yahoo_fin/scrapper/utils/mappers/yahoo/YahooFeignConfig.java
@@ -2,15 +2,17 @@ package com.yahoo_fin.scrapper.utils.mappers.yahoo;
 
 import feign.RequestInterceptor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConfigurationProperties(prefix = "yahoo")
 public class YahooFeignConfig {
-    @Value("${app.rapid-api-key}")
+    @Value("${yahoo.rapid-api-key}")
     private String apiKey;
 
-    @Value("${app.rapid-api-host}")
+    @Value("${yahoo.rapid-api-host}")
     private String host;
 
     @Bean

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,12 +1,17 @@
+spring.config.import=optional:file:src/.env.properties
+
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER}
 
-logging.level.root=DEBUG
+logging.level.root=INFO
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+logging.level.org.springframework.jdbc=DEBUG
+logging.level.com.zaxxer.hikari=DEBUG
 
 spring.jackson.time-zone=${DEFAULT_TIMEZONE}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=scrapper
-spring.config.import=optional:file:.env[.properties]
+spring.config.import=optional:file:src/.env.properties
 
 app.markets[0].country-name=BRAZIL
 app.markets[0].country-code=BR
@@ -24,7 +24,7 @@ app.markets[2].currency=AUD
 
 app.crypto=BTC,ETH,LTC
 
-app.rapid-api-key=${RAPID_API_KEY}
-app.rapid-api-host=${RAPID_API_HOST}
-app.rapid-api-base-url=https://${RAPID_API_HOST}
-app.rapid-api-version=${RAPID_API_VERSION}
+yahoo.rapid-api-key=${RAPID_API_KEY}
+yahoo.rapid-api-host=${RAPID_API_HOST}
+yahoo.rapid-api-base-url=https://${RAPID_API_HOST}
+yahoo.rapid-api-version=${RAPID_API_VERSION}

--- a/src/test/java/com/yahoo_fin/scrapper/currency/service/YahooBackFillerTest.java
+++ b/src/test/java/com/yahoo_fin/scrapper/currency/service/YahooBackFillerTest.java
@@ -1,11 +1,14 @@
 package com.yahoo_fin.scrapper.currency.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo_fin.scrapper.currency.Currency;
 import com.yahoo_fin.scrapper.currency.CurrencyRepository;
 import com.yahoo_fin.scrapper.currency.USDExchangeRate;
 import com.yahoo_fin.scrapper.currency.USDExchangeRateRepository;
 import com.yahoo_fin.scrapper.market.Country;
 import com.yahoo_fin.scrapper.market.CountryRepository;
+import com.yahoo_fin.scrapper.types.records.CurrencyRefill;
 import com.yahoo_fin.scrapper.types.yahoo.ChartResponse;
 import com.yahoo_fin.scrapper.utils.mappers.yahoo.FakeYahooDataFetcher;
 import com.yahoo_fin.scrapper.utils.mappers.yahoo.YahooMapper;
@@ -34,6 +37,8 @@ class YahooBackFillerTest {
 
     @Autowired
     private CountryRepository countryRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     Country fakeCountry01 = new Country("FakeCountry 01", "FKC01");
     Country fakeCountry02 = new Country("FakeCountry 02", "FKC02");
@@ -84,5 +89,94 @@ class YahooBackFillerTest {
         YahooBackFiller yahooBackFiller = new YahooBackFiller(yahooMapper, fakeYahooDataFetcher, exchangeRateRepository);
         USDExchangeRate newestRecord = yahooBackFiller.getNewestRecord(currency_fk01);
         assertEquals(LocalDateTime.MIN, newestRecord.getTimestamp());
+    }
+
+    @Test
+    void fetchAndSaveExchangeRateFirstTime() throws JsonProcessingException {
+        Currency currency_fk01 = new Currency("FakeCountry 01", "FKC01", fakeCountry01);
+        currencyRepository.save(currency_fk01);
+
+        String yahooResponse = """
+                {
+                  "chart": {
+                    "result": [
+                      {
+                        "meta": {
+                          "longName": "FKC01/USD",
+                          "shortName": "FKC01/USD",
+                          "instrumentType": "CURRENCY",
+                          "symbol": "FKC01USD=X"
+                        },
+                        "timestamp": [1776211200, 1778803200, 1781481600, null, 1784073600, 1786752000, 1789430400],
+                        "indicators": {
+                          "quote": [
+                            {
+                              "close": [180.5, 182.1, 180.5, null, 182.1, 180.5, 182.1]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+        ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
+        FakeYahooDataFetcher fakeYahooDataFetcher = new FakeYahooDataFetcher(chartResponse);
+        YahooBackFiller yahooBackFiller = new YahooBackFiller(yahooMapper, fakeYahooDataFetcher, exchangeRateRepository);
+
+        CurrencyRefill currencyRefill = yahooBackFiller.runBackfill(currentDate, currentDate.minusMonths(6), currency_fk01);
+        assertEquals(5, currencyRefill.storedRecords());
+        assertEquals("FKC01", currencyRefill.currencyCode());
+
+        int numberOfRecordsStored = exchangeRateRepository.countByCurrency(currency_fk01);
+        assertEquals(5, numberOfRecordsStored);
+    }
+
+    @Test
+    void fetchAndSaveExchangeRateSecondTime() throws JsonProcessingException {
+        Currency currency_fk01 = new Currency("FakeCountry 01", "FKC01", fakeCountry01);
+        currencyRepository.save(currency_fk01);
+
+        exchangeRateRepository.saveAll(List.of(
+                new USDExchangeRate(1500, currentDate.minusMonths(10), currency_fk01),
+                new USDExchangeRate(1420, currentDate.minusMonths(9), currency_fk01),
+                new USDExchangeRate(1425, currentDate.minusMonths(4), currency_fk01)
+        ));
+
+        // Note that we are returning two records before the default cut date (6 months) - 1776124800 and 1776211200
+        String yahooResponse = """
+                {
+                  "chart": {
+                    "result": [
+                      {
+                        "meta": {
+                          "longName": "FKC01/USD",
+                          "shortName": "FKC01/USD",
+                          "instrumentType": "CURRENCY",
+                          "symbol": "FKC01USD=X"
+                        },
+                        "timestamp": [1776124800, 1776211200, 1778803200, 1781481600, null, 1784073600, 1786752000, 1789430400],
+                        "indicators": {
+                          "quote": [
+                            {
+                              "close": [180.5, 180.5, 182.1, 180.5, null, 182.1, 180.5, 182.1]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+        ChartResponse chartResponse = objectMapper.readValue(yahooResponse, ChartResponse.class);
+        FakeYahooDataFetcher fakeYahooDataFetcher = new FakeYahooDataFetcher(chartResponse);
+        YahooBackFiller yahooBackFiller = new YahooBackFiller(yahooMapper, fakeYahooDataFetcher, exchangeRateRepository);
+
+        CurrencyRefill currencyRefill = yahooBackFiller.runBackfill(currentDate, currentDate.minusMonths(6), currency_fk01);
+        assertEquals(5, currencyRefill.storedRecords());
+        assertEquals("FKC01", currencyRefill.currencyCode());
+
+        int numberOfRecordsStored = exchangeRateRepository.countByCurrencyAndTimestampGreaterThan(currency_fk01, currentDate.minusMonths(6));
+        assertEquals(6, numberOfRecordsStored);
     }
 }

--- a/src/test/java/com/yahoo_fin/scrapper/market/service/DBPreFillerServiceTest.java
+++ b/src/test/java/com/yahoo_fin/scrapper/market/service/DBPreFillerServiceTest.java
@@ -1,6 +1,7 @@
 package com.yahoo_fin.scrapper.market.service;
 
 import com.yahoo_fin.scrapper.AppProperties;
+import com.yahoo_fin.scrapper.currency.CurrencyRepository;
 import com.yahoo_fin.scrapper.market.Country;
 import com.yahoo_fin.scrapper.market.CountryRepository;
 import com.yahoo_fin.scrapper.market.Market;
@@ -38,9 +39,12 @@ class DBPreFillerServiceTest {
     @Autowired
     private AppProperties appProperties;
 
+    @Autowired
+    private CurrencyRepository currencyRepository;
+
     @Test
     void populateCountryAndMarketTableWithEmptyData() {
-        DBPreFillerService dbPreFillerService = new DBPreFillerService(countryRepository, marketRepository, appProperties);
+        DBPreFillerService dbPreFillerService = new DBPreFillerService(countryRepository, marketRepository, appProperties, currencyRepository);
         dbPreFillerService.populateCountryAndMarketTables();
 
         List<Country> countries = countryRepository.findAll();
@@ -52,7 +56,7 @@ class DBPreFillerServiceTest {
 
     @Test
     void populateCountryAndMarketTableWithExistingData() {
-        DBPreFillerService dbPreFillerService = new DBPreFillerService(countryRepository, marketRepository, appProperties);
+        DBPreFillerService dbPreFillerService = new DBPreFillerService(countryRepository, marketRepository, appProperties, currencyRepository);
         dbPreFillerService.populateCountryAndMarketTables();
         dbPreFillerService.populateCountryAndMarketTables();
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,7 +9,7 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 spring.jackson.time-zone=UTC
 
-app.rapid-api-key=fake-api-for-unit-test
-app.rapid-api-host=fakehost.com
-app.rapid-api-base-url=https://fakehost.com
-app.rapid-api-version=v3
+yahoo.rapid-api-key=fake-api-for-unit-test
+yahoo.rapid-api-host=fakehost.com
+yahoo.rapid-api-base-url=https://fakehost.com
+yahoo.rapid-api-version=v3


### PR DESCRIPTION
…ase preparation

- Introduced `CurrencyController` with endpoints for handling `/currency/back-fill` operations using `YahooBackFiller` and `CurrencyListing`.
- Added `MarketController` with `/market/prepare-db` endpoint to streamline country, market, and currency initialization.
- Enhanced `DBPreFillerService` to support currency association during market table population.
- Updated `YahooBackFiller` to improve backfill logic using date constraints for older records.
- Refactored configuration to use `yahoo.rapid-api-*` properties, replacing `app.*` keys.
- Improved test coverage for backfill and database preparation services.
- Updated `.gitignore` and project configuration files for better environment variable handling.

Closes #47 (it also creates an endpoint to prepare the DB).